### PR TITLE
Retira o http: para herdar o protocolo da pagina - #19

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Histórico de Alterações
 1.0.4 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+* Remoção do protocolo no script para herdar o protocolo (HTTP ou HTTPS)
+  [caduvieira]
 
 
 1.0.3 (2014-12-05)

--- a/src/brasil/gov/barra/browser/templates/barra.pt
+++ b/src/brasil/gov/barra/browser/templates/barra.pt
@@ -23,8 +23,8 @@
 <div id="barra-brasil">
 	<a href="http://brasil.gov.br" style="background:#7F7F7F; height: 20px; padding:4px 0 4px 10px; display: block; font-family:sans,sans-serif; text-decoration:none; color:white; ">Portal do Governo Brasileiro</a>
 </div>
-<script src="http://barra.brasil.gov.br/barra.js?cor=cinza" type="text/javascript"
-        tal:attributes="src string:http://barra.brasil.gov.br/barra.js" defer async></script>
+<script src="//barra.brasil.gov.br/barra.js" type="text/javascript"
+        tal:attributes="src string://barra.brasil.gov.br/barra.js" defer async></script>
 </metal:remote>
 </div>
 </metal:barra>


### PR DESCRIPTION
Para atender o novo manual da barra. 

http://barra.governoeletronico.gov.br