### PR TITLE
Retirada do atributo async

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Histórico de Alterações
 
 * Remoção do protocolo no script para herdar o protocolo (HTTP ou HTTPS)
   [caduvieira]
+
 * Remoção do atributo async pois pode causar erro ao executar o script antes do render da página. Obrigado @dadlo. [caduvieira]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,10 @@ Histórico de Alterações
 1.0.4 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+* Remoção do atributo async pois pode causar erro ao executar o script antes do render da página. Obrigado @dadlo. [caduvieira]
+
 * Remoção do protocolo no script para herdar o protocolo (HTTP ou HTTPS)
   [caduvieira]
-
-* Remoção do atributo async pois pode causar erro ao executar o script antes do render da página. Obrigado @dadlo. [caduvieira]
 
 
 1.0.3 (2014-12-05)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Histórico de Alterações
 
 * Remoção do protocolo no script para herdar o protocolo (HTTP ou HTTPS)
   [caduvieira]
+* Remoção do atributo async pois pode causar erro ao executar o script antes do render da página. Obrigado @dadlo. [caduvieira]
 
 
 1.0.3 (2014-12-05)

--- a/src/brasil/gov/barra/browser/templates/barra.pt
+++ b/src/brasil/gov/barra/browser/templates/barra.pt
@@ -24,7 +24,7 @@
 	<a href="http://brasil.gov.br" style="background:#7F7F7F; height: 20px; padding:4px 0 4px 10px; display: block; font-family:sans,sans-serif; text-decoration:none; color:white; ">Portal do Governo Brasileiro</a>
 </div>
 <script src="//barra.brasil.gov.br/barra.js" type="text/javascript"
-        tal:attributes="src string://barra.brasil.gov.br/barra.js" defer async></script>
+        tal:attributes="src string://barra.brasil.gov.br/barra.js" defer></script>
 </metal:remote>
 </div>
 </metal:barra>


### PR DESCRIPTION
Retirando pois pode ter problema ao executar o script antes da renderização completa do rodapé/site.
Obrigado @Dadlo.