### PR TITLE
Barra no fim do body; Mostra msg se não carregar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Histórico de Alterações
 1.1.2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Barra agora é chamada no fim da tag body; Mostra mensagem html, como no
+  padrão estabelecido pelo Ministério do Planejamento, se o javascript não
+  puder ser carregado (closes `#12`_).
+  [idgserpro]
+
 - Adiciona icone da bandeira do Brasil para o configlet do painel de controle.
   [hvelarde]
 
@@ -85,4 +90,5 @@ Histórico de Alterações
 
 .. _`#7`: https://github.com/plonegovbr/brasil.gov.barra/issues/7
 .. _`#10`: https://github.com/plonegovbr/brasil.gov.barra/issues/10
+.. _`#12`: https://github.com/plonegovbr/brasil.gov.barra/issues/12
 .. _`#25`: https://github.com/plonegovbr/brasil.gov.barra/issues/25

--- a/src/brasil/gov/barra/browser/barra_js.py
+++ b/src/brasil/gov/barra/browser/barra_js.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from plone import api
+from plone.app.layout.viewlets import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class BarraViewlet(ViewletBase):
+    """
+    Viewlet que faz a chamada pura para o javascript externo do ministério do
+    planejamento.
+
+    Se o usuário marcar a opção para usar barra local, não renderiza a chamada
+    javascript.
+    """
+    # Indica qual o template sera usado por este viewlet
+    index = ViewPageTemplateFile('templates/barra_js.pt')
+
+    def render(self):
+        portal = api.portal.get()
+        helper = api.content.get_view(
+            name='barra_helper',
+            context=portal,
+            request=self.request,
+        )
+
+        if helper.local():
+            return ''
+        else:
+            return super(BarraViewlet, self).render()

--- a/src/brasil/gov/barra/browser/configure.zcml
+++ b/src/brasil/gov/barra/browser/configure.zcml
@@ -3,12 +3,8 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="brasil.gov.barra">
 
-  <!-- Registra o viewlet da barra com nome de brasil.gov.barra
-       para o viewlet manager
-       plone.app.layout.viewlets.interfaces.IPortalTop
-       apenas se o layer brasil.gov.barra.interfaces.IBarraInstalada
-       estiver disponivel.
-   -->
+  <!--Contém o código html, no topo do site, informando caso não tenha conseguido-->
+  <!--carregar a barra. É recomendado ficar logo após a abertura da tag <body>.-->
   <browser:viewlet
       name="brasil.gov.barra"
       manager="plone.app.layout.viewlets.interfaces.IPortalTop"
@@ -17,10 +13,16 @@
       permission="zope.Public"
       />
 
-  <!-- Registra a browser view BarraHelper com nome de barra_helper
-       apenas se o layer brasil.gov.barra.interfaces.IBarraInstalada
-       estiver disponivel.
-   -->
+  <!--Contém a tag script que chama a barra javascript externa. É recomendado-->
+  <!--ser colocado antes do fechamento da tag body.-->
+  <browser:viewlet
+      name="brasil.gov.barra.js"
+      manager="plone.app.layout.viewlets.interfaces.IPortalFooter"
+      class=".barra_js.BarraViewlet"
+      layer="brasil.gov.barra.interfaces.IBarraInstalada"
+      permission="zope.Public"
+      />
+
   <browser:page
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       name="barra_helper"

--- a/src/brasil/gov/barra/browser/templates/barra.pt
+++ b/src/brasil/gov/barra/browser/templates/barra.pt
@@ -22,11 +22,12 @@
 </div>
 </metal:local>
 <metal:remote tal:condition="not:view/local">
-<div id="barra-brasil">
-        <a href="http://brasil.gov.br" style="background:#7F7F7F; height: 20px; padding:4px 0 4px 10px; display: block; font-family:sans,sans-serif; text-decoration:none; color:white; ">Portal do Governo Brasileiro</a>
+<div id="barra-brasil" style="background:#7F7F7F; height: 20px; padding:0 0 0 10px;display:block;">
+        <ul id="menu-barra-temp" style="list-style:none;">
+                <li style="display:inline; float:left;padding-right:10px; margin-right:10px; border-right:1px solid #EDEDED"><a href="http://brasil.gov.br" style="font-family:sans,sans-serif; text-decoration:none; color:white;">Portal do Governo Brasileiro</a></li>
+                <li><a style="font-family:sans,sans-serif; text-decoration:none; color:white;" href="http://epwg.governoeletronico.gov.br/barra/atualize.html">Atualize sua Barra de Governo</a></li>
+        </ul>
 </div>
-<script src="//barra.brasil.gov.br/barra.js" type="text/javascript"
-        tal:attributes="src string://barra.brasil.gov.br/barra.js" defer></script>
 </metal:remote>
 </div>
 </metal:barra>

--- a/src/brasil/gov/barra/browser/templates/barra_js.pt
+++ b/src/brasil/gov/barra/browser/templates/barra_js.pt
@@ -1,0 +1,3 @@
+<div id="barra_brasil_js">
+    <script defer="defer" src="//barra.brasil.gov.br/barra.js" type="text/javascript"></script>
+</div>

--- a/src/brasil/gov/barra/tests/test_helper.py
+++ b/src/brasil/gov/barra/tests/test_helper.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from brasil.gov.barra.browser.barra import BarraViewlet
+from brasil.gov.barra.browser.barra_js import BarraViewlet as BarraViewletJs
 from brasil.gov.barra.interfaces import IBarraInstalada
 from brasil.gov.barra.testing import INTEGRATION_TESTING
 from plone import api
@@ -7,40 +9,82 @@ from zope.interface import alsoProvides
 import unittest as unittest
 
 
+BARRA_EXTERNA_HTML = u'<script defer="defer" src="//barra.brasil.gov.br/barra.js" type="text/javascript"></script>'
+BARRA_LOCAL_LINK_ACESSO_INFORMACAO = u'<a href="http://brasil.gov.br/barra#acesso-informacao" class="link-barra">Acesso à informação</a>'
+
+
 class HelperViewTest(unittest.TestCase):
     """ Caso de teste da Browser View BarraHelper"""
     layer = INTEGRATION_TESTING
 
     def setUp(self):
         self.portal = self.layer['portal']
+        self.request = self.portal.REQUEST
         pp = api.portal.get_tool('portal_properties')
+        self.barra_helper = api.content.get_view(
+            name='barra_helper',
+            context=self.portal,
+            request=self.request,
+        )
         self.sheet = getattr(pp, 'brasil_gov', None)
+
+        self.barra_viewlet = BarraViewlet(
+            self.portal,
+            self.request,
+            None,
+            None
+        )
+
+        self.barra_viewlet_js = BarraViewletJs(
+            self.portal,
+            self.request,
+            None,
+            None
+        )
+
         # Como nao eh um teste funcional, este objeto
         # REQUEST precisa ser anotado com o browser layer
         alsoProvides(self.portal.REQUEST, IBarraInstalada)
 
     def test_helper_view_registration(self):
         """ Validamos se BarraHelper esta registrada"""
-        view = api.content.get_view(
-            name='barra_helper',
-            context=self.portal,
-            request=self.portal.REQUEST,
-        )
-        view = view.__of__(self.portal)
+        view = self.barra_helper.__of__(self.portal)
         self.assertTrue(view)
 
     def test_helper_view_local(self):
         """Uso do metodo local"""
-        # Obtemos a Browser view
-        view = api.content.get_view(
-            name='barra_helper',
-            context=self.portal,
-            request=self.portal.REQUEST,
-        )
         # Validamos que ela retorne o valor padrao para
         # o metodo remoto(configurado em profiles/default/propertiestool.xml)
-        self.assertFalse(view.local())
+        self.assertFalse(self.barra_helper.local())
         # Alteramos o valor para hospedagem para local
         self.sheet.local = True
         # O resultado da consulta a Browser View deve se adequar
-        self.assertTrue(view.local())
+        self.assertTrue(self.barra_helper.local())
+
+    def test_helper_false_mostra_barra_remota(self):
+        """
+        Não marcando a opção 'local', deve mostrar barra externa e não deve
+        aparecer barra interna.
+        """
+        self.barra_viewlet.update()
+        self.assertFalse(
+            BARRA_LOCAL_LINK_ACESSO_INFORMACAO in self.barra_viewlet.render()
+        )
+
+        self.barra_viewlet_js.update()
+        self.assertTrue(BARRA_EXTERNA_HTML in self.barra_viewlet_js.render())
+
+    def test_helper_true_mostra_barra_local(self):
+        """
+        Marcando opção local, deve mostrar barra local e não deve aparecer
+        barra externa.
+        """
+        self.sheet.local = True
+
+        self.barra_viewlet.update()
+        self.assertTrue(
+            BARRA_LOCAL_LINK_ACESSO_INFORMACAO in self.barra_viewlet.render()
+        )
+
+        self.barra_viewlet_js.update()
+        self.assertFalse(BARRA_EXTERNA_HTML in self.barra_viewlet_js.render())


### PR DESCRIPTION
Atende https://github.com/plonegovbr/brasil.gov.barra/issues/12

Barra agora é chamada no fim da tag body; Mostra mensagem html, como no
padrão estabelecido pelo Ministério do Planejamento, se o javascript não
puder ser carregado.